### PR TITLE
Fix facedof_interior_indices

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -54,7 +54,7 @@ function Ferrite.facedof_interior_indices(ip::InterfaceCellInterpolation{<:Abstr
     here  = map(dofs -> map(d -> d + offset, dofs), basedofs)
     offset += length(basedofs)
     there = map(dofs -> map(d -> d + offset, dofs), basedofs)
-    return (here, there)
+    return (here..., there...)
 end
 
 #########################################################


### PR DESCRIPTION
This fixes the implementation here which was based on an inconsistent implementation in Ferrite. Note that the fix here must be synced with Ferrite.jl, see https://github.com/Ferrite-FEM/Ferrite.jl/pull/1190 

I haven't tested, but the current state will cause an error (AFAIU) if one tries to use interface elements with e.g. `base = Lagrange{RefTriangle, 3}()`.